### PR TITLE
Add support for Image source object

### DIFF
--- a/PhotoGrid.js
+++ b/PhotoGrid.js
@@ -61,7 +61,7 @@ class PhotoGrid extends Component {
               onPress={() => this.props.onPressImage && this.props.onPressImage(image)}>
               <ImageLoad
                 style={[styles.image, { width: firstImageWidth, height: firstImageHeight }, this.props.imageStyle]}
-                source={{ uri: image }}
+                source={typeof image === 'string' ? { uri: image } : image}
                 {...imageProps}
               />
             </TouchableOpacity>
@@ -76,7 +76,7 @@ class PhotoGrid extends Component {
                   {this.props.source.length > 5 && index === secondViewImages.length - 1 ? (
                     <Image
                       style={[styles.image, { width: secondImageWidth, height: secondImageHeight }, this.props.imageStyle]}
-                      source={{ uri: image }}
+                      source={typeof image === 'string' ? { uri: image } : image}
                     >
                       <View style={styles.lastWrapper}>
                         <Text style={[styles.textCount, this.props.textStyles]}>+{this.props.source.length - 5}</Text>
@@ -85,7 +85,7 @@ class PhotoGrid extends Component {
                   )
                     : <ImageLoad
                       style={[styles.image, { width: secondImageWidth, height: secondImageHeight }, this.props.imageStyle]}
-                      source={{ uri: image }}
+                      source={typeof image === 'string' ? { uri: image } : image}
                       {...imageProps}
                     />}
                 </TouchableOpacity>

--- a/readme.md
+++ b/readme.md
@@ -16,11 +16,40 @@ const images = [
 
 ```
 
+## Custom Image source object
+
+The `source` prop also accepts an Array of source objects like so:
+
+```js
+const images = [
+  {
+    uri: 'https://cdn.pixabay.com/photo/2017/06/09/09/39/adler-2386314_960_720.jpg',
+    headers: {
+      Authorization: 'Bearer xyz'
+    }
+  },
+  {
+    uri: 'https://cdn.pixabay.com/photo/2017/06/02/18/24/fruit-2367029_960_720.jpg',
+    headers: {
+      Authorization: 'Bearer xyz'
+    }
+  },
+  {
+    uri: 'https://cdn.pixabay.com/photo/2016/08/12/22/34/apple-1589869_960_720.jpg'
+    headers: {
+      Authorization: 'Bearer xyz'
+    }
+  }
+]
+...
+<PhotoGrid source={images} onPressImage={source => this.showImage(source.uri)} />
+```
+
 # Props
 
 Property | Type | Description
 ------------ | ------------- | -------------
-source | PropTypes.array | Array uri of image
+source | PropTypes.array | Array containing Image uri string or source object
 width | PropTypes.number | Container width
 height | PropTypes.number | Container height
 ratio | PropTypes.float | Split screen ratio


### PR DESCRIPTION
I've added support for an Image source object rather than just a URI string.

Personally this allows me to provide custom headers to the HTTP request made by the Image component (Although the docs haven't been updated, Image does accept a `headers` object now).

You could also do this:

```js
const images = [require('./first.png'), require('./second.png')];
<PhotoGrid source={images} onPressImage={image => this.showImage(image)} />
```