### PR TITLE
Bumped react-native-image-placeholder

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   "author": "Duy Luong",
   "license": "MIT",
   "dependencies": {
-    "react-native-image-placeholder": "1.0.7"
+    "react-native-image-placeholder": "1.0.13"
   }
 }


### PR DESCRIPTION
React.PropTypes were [removed](https://reactjs.org/blog/2017/09/26/react-v16.0.html) in react@16 