### PR TITLE
Pass event up & add amount of not showing images

### DIFF
--- a/PhotoGrid.js
+++ b/PhotoGrid.js
@@ -12,13 +12,25 @@ class PhotoGrid extends PureComponent {
 
     this.state = {
       width: props.width,
-      height: props.height
+      height: props.height,
     }
   }
 
   static defaultProps = {
     numberImagesToShow: 0,
+    onPressImage: () => {},
   }
+
+  isLastImage = (index, secondViewImages) => {
+    const { source, numberImagesToShow } = this.props
+
+    return (source.length > 5 || numberImagesToShow) && index === secondViewImages.length - 1
+  }
+
+  handlePressImage = (event, { image, index }, secondViewImages) =>
+    this.props.onPressImage(event, image, {
+      isLastImage: index && this.isLastImage(index, secondViewImages),
+    })
 
   render () {
     const { imageProps } = this.props
@@ -63,7 +75,7 @@ class PhotoGrid extends PureComponent {
         <View style={{ flex: 1, flexDirection: direction === 'row' ? 'column' : 'row' }}>
           {firstViewImages.map((image, index) => (
             <TouchableOpacity activeOpacity={0.7} key={index} style={{ flex: 1 }}
-              onPress={(event) => this.props.onPressImage && this.props.onPressImage(event, image)}>
+              onPress={event => this.handlePressImage(event, { image })}>
               <ImageLoad
                 style={[styles.image, { width: firstImageWidth, height: firstImageHeight }, this.props.imageStyle]}
                 source={typeof image === 'string' ? { uri: image } : image}
@@ -77,8 +89,8 @@ class PhotoGrid extends PureComponent {
             <View style={{ width: secondViewWidth, height: secondViewHeight, flexDirection: direction === 'row' ? 'column' : 'row' }}>
               {secondViewImages.map((image, index) => (
                 <TouchableOpacity activeOpacity={0.7} key={index} style={{ flex: 1 }}
-                onPress={(event) => this.props.onPressImage && this.props.onPressImage(event, image)}>
-                {(this.props.source.length > 5 || this.props.numberImagesToShow) && index === secondViewImages.length - 1 ? (
+                onPress={event => this.handlePressImage(event, { image, index }, secondViewImages)}>
+                {this.isLastImage(index, secondViewImages) ? (
                     <ImageBackground
                       style={[styles.image, { width: secondImageWidth, height: secondImageHeight }, this.props.imageStyle]}
                       source={typeof image === 'string' ? { uri: image } : image}

--- a/PhotoGrid.js
+++ b/PhotoGrid.js
@@ -77,8 +77,8 @@ class PhotoGrid extends PureComponent {
             <View style={{ width: secondViewWidth, height: secondViewHeight, flexDirection: direction === 'row' ? 'column' : 'row' }}>
               {secondViewImages.map((image, index) => (
                 <TouchableOpacity activeOpacity={0.7} key={index} style={{ flex: 1 }}
-                  onPress={() => this.props.onPressImage && this.props.onPressImage(image)}>
-                  {(this.props.source.length > 5 || this.props.numberImagesToShow) && index === secondViewImages.length - 1 ? (
+                onPress={(event) => this.props.onPressImage && this.props.onPressImage(event, image)}>
+                {(this.props.source.length > 5 || this.props.numberImagesToShow) && index === secondViewImages.length - 1 ? (
                     <ImageBackground
                       style={[styles.image, { width: secondImageWidth, height: secondImageHeight }, this.props.imageStyle]}
                       source={typeof image === 'string' ? { uri: image } : image}

--- a/PhotoGrid.js
+++ b/PhotoGrid.js
@@ -138,7 +138,6 @@ PhotoGrid.defaultProps = {
 const styles = {
   image: {
     flex: 1,
-    resizeMode: 'cover',
     borderWidth: 1,
     borderColor: '#fff'
   },

--- a/PhotoGrid.js
+++ b/PhotoGrid.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import { View, Text, Dimensions, TouchableOpacity, ImageBackground } from 'react-native'
 import _ from 'lodash'
@@ -6,13 +6,18 @@ import ImageLoad from 'react-native-image-placeholder'
 
 const { width } = Dimensions.get('window')
 
-class PhotoGrid extends Component {
+class PhotoGrid extends PureComponent {
   constructor (props) {
     super(props)
+
     this.state = {
       width: props.width,
       height: props.height
     }
+  }
+
+  static defaultProps = {
+    numberImagesToShow: 0,
   }
 
   render () {
@@ -52,13 +57,13 @@ class PhotoGrid extends Component {
 
     const secondViewWidth = direction === 'column' ? width : (width * ratio)
     const secondViewHeight = direction === 'column' ? (height * ratio) : height
-    // console.log(this.state)
+
     return source.length ? (
       <View style={[{ flexDirection: direction, width, height }, this.props.styles]}>
         <View style={{ flex: 1, flexDirection: direction === 'row' ? 'column' : 'row' }}>
           {firstViewImages.map((image, index) => (
             <TouchableOpacity activeOpacity={0.7} key={index} style={{ flex: 1 }}
-              onPress={() => this.props.onPressImage && this.props.onPressImage(image)}>
+              onPress={(event) => this.props.onPressImage && this.props.onPressImage(event, image)}>
               <ImageLoad
                 style={[styles.image, { width: firstImageWidth, height: firstImageHeight }, this.props.imageStyle]}
                 source={typeof image === 'string' ? { uri: image } : image}
@@ -73,13 +78,13 @@ class PhotoGrid extends Component {
               {secondViewImages.map((image, index) => (
                 <TouchableOpacity activeOpacity={0.7} key={index} style={{ flex: 1 }}
                   onPress={() => this.props.onPressImage && this.props.onPressImage(image)}>
-                  {this.props.source.length > 5 && index === secondViewImages.length - 1 ? (
+                  {(this.props.source.length > 5 || this.props.numberImagesToShow) && index === secondViewImages.length - 1 ? (
                     <ImageBackground
                       style={[styles.image, { width: secondImageWidth, height: secondImageHeight }, this.props.imageStyle]}
                       source={typeof image === 'string' ? { uri: image } : image}
                     >
                       <View style={styles.lastWrapper}>
-                        <Text style={[styles.textCount, this.props.textStyles]}>+{this.props.source.length - 5}</Text>
+                        <Text style={[styles.textCount, this.props.textStyles]}>+{this.props.numberImagesToShow || this.props.source.length - 5}</Text>
                       </View>
                     </ImageBackground>
                   )


### PR DESCRIPTION
Fixes #6.

---

This PR adds:

- A breaking change to `onPressImage` prop, the first argument is now the `event`;
- Prop `numberImagesToShow` to show the amount on the last image with a `+` prefix;
- Separate `isLastImage` & `handlePressImage` handlers into functions so they are easier to use.